### PR TITLE
Upgrade

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,6 +33,7 @@ module.exports = function(grunt) {
                     ttf: true,
                     eot: true,
                     woff: true,
+                    woff2: true,
                     svg: true,
                     fontname: 'Ubuntu',
                     fontstyles: '300,500,700',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,7 +38,8 @@ module.exports = function(grunt) {
                     fontname: 'Ubuntu',
                     fontstyles: '300,500,700',
                     cssdest: 'tmp/ubuntu.css',
-                    cssprefix: ''
+                    cssprefix: '',
+                    subset: ''
                 }
             }
         }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,6 +37,7 @@ module.exports = function(grunt) {
                     svg: true,
                     fontname: 'Ubuntu',
                     fontstyles: '300,500,700',
+                    fontdest: '',
                     cssdest: 'tmp/ubuntu.css',
                     cssprefix: '',
                     subset: ''

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2014 Jan Jaap Hakvoort
+Copyright (c) 2014–2015 Jan Jaap Hakvoort
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ Along-side, specify the font file-types you want to download. Not all font file-
 
 ## License
 
-(C) [www.optimalisatie.nl](https://optimalisatie.nl) 2014, released under the MIT license
+(C) [www.optimalisatie.nl](https://optimalisatie.nl) 2014–2015, released under the MIT license

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ grunt-goog-webfont-dl [![Dependency Status](https://david-dm.org/optimalisatie/g
 
 A grunt wrapper for Google WebFont Downloader ([goog-webfont-dl](https://github.com/jrnewell/goog-webfont-dl)) by [James Newell](https://github.com/jrnewell).
 
-> [goog-webfont-dl](https://github.com/jrnewell/goog-webfont-dl) is a Google WebFont utility to download webfont files to your local machine. It attempts to retreieve WOFF, TTF, EOT, and SVG file formats using custom user-agent strings. It will then output a CSS3 snippet that you can use directly in your project.
+> [goog-webfont-dl](https://github.com/jrnewell/goog-webfont-dl) is a Google WebFont utility to download webfont files to your local machine. It attempts to retreieve WOFF, WOFF2, TTF, EOT, and SVG file formats using custom user-agent strings. It will then output a CSS3 snippet that you can use directly in your project.
 
 ## Getting Started
 
@@ -36,7 +36,7 @@ Task targets, files and options may be specified according to the grunt [Configu
 Use the `grunt-goog-webfont-dl` task by specifying a target destination (file) for your font-CSS, the name of the [Google Font](https://www.google.com/fonts/) and the font-styles.
 Below this is `dist/ubuntu.css` for the [Ubuntu](https://www.google.com/fonts/specimen/Ubuntu) font.
 
-Along-side, specify the font file-types you want to download. Not all font file-types are supported in every browser. Check compatibility: [TTF](http://caniuse.com/#feat=ttf), [EOT](http://caniuse.com/#search=eot), [WOFF](http://caniuse.com/#search=woff), [SVG](http://caniuse.com/#search=svg) 
+Along-side, specify the font file-types you want to download. Not all font file-types are supported in every browser. Check compatibility: [TTF](http://caniuse.com/#feat=ttf), [EOT](http://caniuse.com/#search=eot), [WOFF](http://caniuse.com/#search=woff), [WOFF2](http://caniuse.com/#search=woff2), [SVG](http://caniuse.com/#search=svg)
 
 ```js
 "goog-webfont-dl": {
@@ -45,6 +45,7 @@ Along-side, specify the font file-types you want to download. Not all font file-
           ttf: true,
           eot: true,
           woff: true,
+          woff2: true,
           svg: true,
           fontname: 'Ubuntu',
           fontstyles: '300,500,700',
@@ -58,7 +59,7 @@ Along-side, specify the font file-types you want to download. Not all font file-
 ## Maintainers
 
 * [@optimalisatie](https://github.com/optimalisatie)
- 
+
 ## Contributors
 
 * [@michael-k](https://github.com/michael-k)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Along-side, specify the font file-types you want to download. Not all font file-
           svg: true,
           fontname: 'Ubuntu',
           fontstyles: '300,500,700',
+          fontdest: '',
           cssdest: 'dist/ubuntu.css',
           cssprefix: '',
           subset: ''

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-grunt-goog-webfont-dl
+grunt-goog-webfont-dl [![Dependency Status](https://david-dm.org/optimalisatie/grunt-goog-webfont-dl.svg)](https://david-dm.org/optimalisatie/grunt-goog-webfont-dl)
 =====================
 
 A grunt wrapper for Google WebFont Downloader ([goog-webfont-dl](https://github.com/jrnewell/goog-webfont-dl)) by [James Newell](https://github.com/jrnewell).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Along-side, specify the font file-types you want to download. Not all font file-
           fontname: 'Ubuntu',
           fontstyles: '300,500,700',
           cssdest: 'dist/ubuntu.css',
-          cssprefix: ''
+          cssprefix: '',
+          subset: ''
       }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "grunt": "*",
     "grunt-contrib-clean": "^0.6.0",
-    "grunt-contrib-jshint": "~0.6.0"
+    "grunt-contrib-jshint": "~0.11.1"
   },
   "peerDependencies": {
     "grunt": "*"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/filamentgroup/grunt-criticalcss/blob/master/LICENSE-MIT"
+      "url": "https://github.com/optimalisatie/grunt-goog-webfont-dl/blob/master/LICENSE-MIT"
     }
   ],
   "main": "Gruntfile.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-goog-webfont-dl",
   "description": "Grunt wrapper for goog-webfont-dl",
-  "version": "0.0.2",
+  "version": "0.1.1",
   "homepage": "https://github.com/optimalisatie/grunt-goog-webfont-dl",
   "author": {
     "name": "Jan Jaap Hakvoort",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "goog-webfont-dl": "0.0.4",
-    "lodash": "^2.4.1"
+    "goog-webfont-dl": "0.1.1",
+    "lodash": "^3.6.0"
   },
   "devDependencies": {
     "grunt": "*",

--- a/tasks/goog-webfont-dl.js
+++ b/tasks/goog-webfont-dl.js
@@ -27,6 +27,7 @@ module.exports = function(grunt) {
             svg: true,
             fontname: '',
             fontstyles: '',
+            fontdest: '',
             cssdest: '',
             cssprefix: '',
             subset: ''
@@ -39,6 +40,11 @@ module.exports = function(grunt) {
 
         if (options.fontstyles !== '' && !_.isString(options.fontstyles)) {
             grunt.fail.warn('Invalid Google font-styles.');
+            return;
+        }
+
+        if (options.fontdest !== '' && !_.isString(options.fontdest)) {
+            grunt.fail.warn('Invalid font files destination.');
             return;
         }
 
@@ -92,6 +98,12 @@ module.exports = function(grunt) {
                 case "fontstyles":
                     if (value !== '') {
                         args.push('--styles');
+                        args.push(value);
+                    }
+                    break;
+                case "fontdest":
+                    if (value !== '') {
+                        args.push('--destination');
                         args.push(value);
                     }
                     break;

--- a/tasks/goog-webfont-dl.js
+++ b/tasks/goog-webfont-dl.js
@@ -33,33 +33,8 @@ module.exports = function(grunt) {
             subset: ''
         });
 
-        if (options.fontname === '' || !_.isString(options.fontname)) {
-            grunt.fail.warn('Invalid Google font-name.');
-            return;
-        }
-
-        if (options.fontstyles !== '' && !_.isString(options.fontstyles)) {
-            grunt.fail.warn('Invalid Google font-styles.');
-            return;
-        }
-
-        if (options.fontdest !== '' && !_.isString(options.fontdest)) {
-            grunt.fail.warn('Invalid font files destination.');
-            return;
-        }
-
-        if (options.cssdest !== '' && !_.isString(options.cssdest)) {
-            grunt.fail.warn('Invalid CSS file destination.');
-            return;
-        }
-
-        if (options.cssprefix !== '' && !_.isString(options.cssprefix)) {
-            grunt.fail.warn('Invalid CSS prefix.');
-            return;
-        }
-
-        if (options.subset !== '' && !_.isString(options.subset)) {
-            grunt.fail.warn('Invalid character subset.');
+        if (options.fontname === '') {
+            grunt.fail.warn('Fontname must not be empty.');
             return;
         }
 
@@ -90,40 +65,51 @@ module.exports = function(grunt) {
         // Loop through the options and add them to args
         // Omit urls from the options to be passed through
         _.each(options, function(value, key) {
+            if (value === '') {
+                return;
+            }
             switch (key) {
                 case "fontname":
+                    if (!_.isString(value)) {
+                        grunt.fail.warn('Invalid Google font-name.');
+                    }
                     args.push('--font');
                     args.push(value);
                     break;
                 case "fontstyles":
-                    if (value !== '') {
-                        args.push('--styles');
-                        args.push(value);
+                    if (!_.isString(value)) {
+                        grunt.fail.warn('Invalid Google font-styles.');
                     }
+                    args.push('--styles');
+                    args.push(value);
                     break;
                 case "fontdest":
-                    if (value !== '') {
-                        args.push('--destination');
-                        args.push(value);
+                    if (!_.isString(value)) {
+                        grunt.fail.warn('Invalid font files destination.');
                     }
+                    args.push('--destination');
+                    args.push(value);
                     break;
                 case "cssdest":
-                    if (value !== '') {
-                        args.push('--out');
-                        args.push(value);
+                    if (!_.isString(value)) {
+                        grunt.fail.warn('Invalid CSS file destination.');
                     }
+                    args.push('--out');
+                    args.push(value);
                     break;
                 case "cssprefix":
-                    if (value !== '') {
-                        args.push('--prefix');
-                        args.push(value);
+                    if (!_.isString(value)) {
+                        grunt.fail.warn('Invalid CSS prefix.');
                     }
+                    args.push('--prefix');
+                    args.push(value);
                     break;
                 case "subset":
-                    if (value !== '') {
-                        args.push('--subset');
-                        args.push(value);
+                    if (!_.isString(value)) {
+                        grunt.fail.warn('Invalid character subset.');
                     }
+                    args.push('--subset');
+                    args.push(value);
                     break;
             }
         });

--- a/tasks/goog-webfont-dl.js
+++ b/tasks/goog-webfont-dl.js
@@ -28,7 +28,8 @@ module.exports = function(grunt) {
             fontname: '',
             fontstyles: '',
             cssdest: '',
-            cssprefix: ''
+            cssprefix: '',
+            subset: ''
         });
 
         if (options.fontname === '' || !_.isString(options.fontname)) {
@@ -48,6 +49,11 @@ module.exports = function(grunt) {
 
         if (options.cssprefix !== '' && !_.isString(options.cssprefix)) {
             grunt.fail.warn('Invalid CSS prefix.');
+            return;
+        }
+
+        if (options.subset !== '' && !_.isString(options.subset)) {
+            grunt.fail.warn('Invalid character subset.');
             return;
         }
 
@@ -96,6 +102,12 @@ module.exports = function(grunt) {
                 case "cssprefix":
                     if (value !== '') {
                         args.push('--prefix');
+                        args.push(value);
+                    }
+                    break;
+                case "subset":
+                    if (value !== '') {
+                        args.push('--subset');
                         args.push(value);
                     }
                     break;

--- a/tasks/goog-webfont-dl.js
+++ b/tasks/goog-webfont-dl.js
@@ -23,6 +23,7 @@ module.exports = function(grunt) {
             ttf: true,
             eot: true,
             woff: true,
+            woff2: true,
             svg: true,
             fontname: '',
             fontstyles: '',
@@ -55,7 +56,7 @@ module.exports = function(grunt) {
         var args = [];
         var all = true;
         var types = [];
-        _.each(['ttf','eot','woff','svg'], function(value, key) {
+        _.each(['ttf','eot','woff','woff2','svg'], function(value, key) {
             if (options[value] === false) {
                 all = false;
             } else {

--- a/tasks/goog-webfont-dl.js
+++ b/tasks/goog-webfont-dl.js
@@ -48,7 +48,7 @@ module.exports = function(grunt) {
             return;
         }
 
-        if (options.cssdest === '' || !_.isString(options.cssdest)) {
+        if (options.cssdest !== '' && !_.isString(options.cssdest)) {
             grunt.fail.warn('Invalid CSS file destination.');
             return;
         }
@@ -108,8 +108,10 @@ module.exports = function(grunt) {
                     }
                     break;
                 case "cssdest":
-                    args.push('--out');
-                    args.push(value);
+                    if (value !== '') {
+                        args.push('--out');
+                        args.push(value);
+                    }
                     break;
                 case "cssprefix":
                     if (value !== '') {


### PR DESCRIPTION
- Updated dependencies and devDependencies.
- Added a badge to show to show the status of the dependencies.
- Added support for WOFF2, character subsets and font destination (all supported by goog-webfont-dl
  v0.1.1).
- cssdest may be empty.
- Bumped version to 0.1.1. (Skipped 0.1.0 because it was already specified in the initial commit.)
