### PR TITLE
Path for new NPM dependencies layout

### DIFF
--- a/tasks/goog-webfont-dl.js
+++ b/tasks/goog-webfont-dl.js
@@ -118,7 +118,7 @@ module.exports = function(grunt) {
         grunt.log.write('Start download of Google WebFont sourcefiles...');
 
         grunt.util.spawn({
-            cmd: 'node_modules/grunt-goog-webfont-dl/node_modules/goog-webfont-dl/index.js',
+            cmd: require.resolve('goog-webfont-dl'),
             args: args
         }, function(err, result, code) {
 


### PR DESCRIPTION
With new versions of npm, goog-webfont-dl is located in
_node_modules/goog-webfont-dl/index.js_
instead of
_node_modules/grunt-goog-webfont-dl/node_modules/goog-webfont-dl/index.js_
